### PR TITLE
Add an Option for Stateful Server to be compatible with OpenWorkflow

### DIFF
--- a/android-client/app/src/main/java/edu/cmu/cs/gabrielclient/Const.java
+++ b/android-client/app/src/main/java/edu/cmu/cs/gabrielclient/Const.java
@@ -57,7 +57,7 @@ public class Const {
     // to be "true". If the user state is tracked on the server side, and the server will not
     // send duplicate instructions, then "false".
     // FSM-based cognitive engines generated with gabrieltool.statemachine set this field to "false"
-    public static final boolean DEDUPLICATE_RESPONSE_BY_ENGINE_UPDATE_COUNT = true;
+    public static boolean DEDUPLICATE_RESPONSE_BY_ENGINE_UPDATE_COUNT = true;
 
     // audio configurations
     public static final int RECORDER_SAMPLERATE = 16000;

--- a/android-client/app/src/main/java/edu/cmu/cs/gabrielclient/ServerListActivity.java
+++ b/android-client/app/src/main/java/edu/cmu/cs/gabrielclient/ServerListActivity.java
@@ -57,6 +57,7 @@ public class ServerListActivity extends AppCompatActivity  {
     SeekBar seekBar = null;
     TextView intervalLabel = null;
     Switch subtitles = null;
+    Switch serverStateful = null;
     EditText speechDedupInterval = null;
     CameraManager camMan = null;
     private SharedPreferences mSharedPreferences;
@@ -110,6 +111,7 @@ public class ServerListActivity extends AppCompatActivity  {
                 MODE_PRIVATE);
 
         // app options
+        // subtitle
         subtitles = (Switch) findViewById(R.id.subtitles);
         subtitles.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
@@ -121,6 +123,25 @@ public class ServerListActivity extends AppCompatActivity  {
         });
         subtitles.setChecked(mSharedPreferences.getBoolean("option:subtitles", false));
 
+        // stateful server
+        // if server is stateful, DEDUPLICATE_RESPONSE_BY_ENGINE_UPDATE_COUNT should be
+        // turned off.
+        serverStateful = (Switch) findViewById(R.id.serverStateful);
+        serverStateful.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                Const.DEDUPLICATE_RESPONSE_BY_ENGINE_UPDATE_COUNT = !isChecked;
+                SharedPreferences.Editor editor = mSharedPreferences.edit();
+                editor.putBoolean("option:serverStateful",
+                        isChecked);
+                editor.commit();
+            }
+        });
+        boolean initialServerStateful= mSharedPreferences.getBoolean("option:serverStateful",
+                !Const.DEDUPLICATE_RESPONSE_BY_ENGINE_UPDATE_COUNT);
+        Const.DEDUPLICATE_RESPONSE_BY_ENGINE_UPDATE_COUNT = !initialServerStateful;
+        serverStateful.setChecked(initialServerStateful);
+
+        // dedup interval
         speechDedupInterval = (EditText) findViewById(R.id.speechDedupInterval);
         speechDedupInterval.addTextChangedListener(
                 new TextWatcher() {

--- a/android-client/app/src/main/res/layout/activity_serverlist.xml
+++ b/android-client/app/src/main/res/layout/activity_serverlist.xml
@@ -44,6 +44,13 @@
         android:layout_marginLeft="20dp"
         android:text="@string/subtitles" />
 
+    <Switch
+        android:id="@+id/serverStateful"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="20dp"
+        android:text="@string/server_state" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/android-client/app/src/main/res/values/strings.xml
+++ b/android-client/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <!-- activity_serverlist.xml -->
     <string name="options_heading">Options</string>
     <string name="subtitles">Show Subtitles for Audio Feedback</string>
+    <string name="server_state">Stateful Server (e.g. OpenWorkflow Applications)</string>
     <string name="speech_dedup">Period to Suppress Identical Speech (in Seconds)</string>
     <string name="serverlist_heading">Server List</string>
     <string name="name_subheading">Name</string>

--- a/android-client/gradle.properties
+++ b/android-client/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+


### PR DESCRIPTION
Current Gabriel Android client has DEDUPLICATE_RESPONSE_BY_ENGINE_UPDATE_COUNT turned on by default, which will [suppress instructions with an engine_field.update_count less/equal to the previous engine_field.update_count](https://github.com/cmusatyalab/gabriel-instruction/blob/6c16480b5e92a23e6efd8c65d466f8070a21fd3a/android-client/app/src/main/java/edu/cmu/cs/gabrielclient/network/InstructionComm.java#L41). This causes a bug for OpenWorkflow application, (or in general, stateful server applications), because when token number > 1, there could be multiple response packets in flight with the same engine_field.update_count.

Therefore, DEDUPLICATE_RESPONSE_BY_ENGINE_UPDATE_COUNT should be turned off for stateful servers. This pull request adds a GUI option to turn it off.
